### PR TITLE
fix: settings text color not visible in dark theme mode

### DIFF
--- a/chooloolib/src/main/java/com/chooloo/www/chooloolib/interactor/color/ColorsInteractorImpl.kt
+++ b/chooloolib/src/main/java/com/chooloo/www/chooloolib/interactor/color/ColorsInteractorImpl.kt
@@ -1,7 +1,9 @@
 package com.chooloo.www.chooloolib.interactor.color
 
 import android.content.Context
+import android.content.res.Configuration
 import android.util.TypedValue
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
 import com.chooloo.www.chooloolib.util.baseobservable.BaseObservable
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -13,7 +15,18 @@ class ColorsInteractorImpl @Inject constructor(
     @ApplicationContext private val context: Context
 ) : BaseObservable<ColorsInteractor.Listener>(), ColorsInteractor {
 
-    override fun getColor(colorRes: Int) = ContextCompat.getColor(context, colorRes)
+    private fun getThemedContext(): Context {
+        val configuration = Configuration(context.resources.configuration)
+        configuration.uiMode = when (AppCompatDelegate.getDefaultNightMode()) {
+            AppCompatDelegate.MODE_NIGHT_NO -> Configuration.UI_MODE_NIGHT_NO
+            AppCompatDelegate.MODE_NIGHT_YES -> Configuration.UI_MODE_NIGHT_YES
+            else -> configuration.uiMode
+        }
+        return context.createConfigurationContext(configuration)
+    }
+
+    override fun getColor(colorRes: Int) = ContextCompat.getColor(getThemedContext(), colorRes)
+
     override fun getAttrColor(colorRes: Int) =
         TypedValue().also { context.theme.resolveAttribute(colorRes, it, true) }.data
 }


### PR DESCRIPTION
As application context doesn't have any information about current theme, the color from 
`ContextCompat.getColor(context, colorRes)` is default color irrespective of theme, so created a themed context which provides context with current theme, and `ContextCompact` now returns theme specific color